### PR TITLE
Make it build even if no templates exist

### DIFF
--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -69,19 +69,12 @@ module.exports = function(grunt) {
 
       }).join(grunt.util.normalizelf('\n'));
 
-      if (moduleNames.length) {
+      var target = f.module || options.module;
 
-        var target = f.module || options.module;
-
-        var bundle = "angular.module('" + target + "', [" + 
-        moduleNames.join(', ') + "]);\n\n" + modules;
-        grunt.file.write(f.dest, bundle);
-        grunt.log.writeln('File "' + f.dest + '" created.');
-
-      } else {
-
-        grunt.log.warn('No source templates found, not creating ' + f.dest);
-      }
+      var bundle = "angular.module('" + target + "', [" + 
+      moduleNames.join(', ') + "]);\n\n" + modules;
+      grunt.file.write(f.dest, bundle);
+      grunt.log.writeln('File "' + f.dest + '" created.');
     });
   });
 };


### PR DESCRIPTION
I don't really see the point of the check to see if any files exist before building the module.

When I have a new app using html2js in the build step, there are no templates yet.  But I still want to include "templates-app" as a dependency in my angular module.  With it not building the module if no templates exist, though, templates-app module is never declared and I get an error.

This makes it a bit easier to get started.  It will just declare an empty module if there are no templates.

I realize I could just create an empty test template, but why make the user go to that trouble?
