### PR TITLE
Add no-bundle-module option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Default value: `templates-TARGET`
 
 The name of the parent Angular module for each set of templates.  Defaults to the task target prefixed by `templates-`.
 
+If no bundle module is desired, set this to false.
+
 ### Usage Examples
 
 See the `Gruntfile.js` in the project source code for various configuration examples.

--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -69,12 +69,17 @@ module.exports = function(grunt) {
 
       }).join(grunt.util.normalizelf('\n'));
 
-      var target = f.module || options.module;
-
-      var bundle = "angular.module('" + target + "', [" + 
-      moduleNames.join(', ') + "]);\n\n" + modules;
-      grunt.file.write(f.dest, bundle);
-      grunt.log.writeln('File "' + f.dest + '" created.');
+      var bundle = "";
+      var targetModule = f.module || options.module;
+      //Allow a 'no targetModule if module is null' option
+      if (targetModule) {
+        bundle = "angular.module('" + targetModule + "', [" + 
+          moduleNames.join(', ') + "]);\n\n";
+      }
+      grunt.file.write(f.dest, bundle + modules);
     });
+    //Just have one output, so if we making thirty files it only does one line
+    grunt.log.writeln("Successfully converted "+(""+this.files.length).green +
+                      " html templates to js.");
   });
 };


### PR DESCRIPTION
If the user wants to create lots of files, one for each template, then
he probably will want to create his own bundle module. The user can
now set the `module` option to null to create no bundle module of all
the templates.

We do this in angular-ui/bootstrap.

I also made the logging have fancy green colors, and only give one output for everything.
