### PR TITLE
Add optional rename function for custom module identifier name

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -94,6 +94,15 @@ module.exports = function(grunt) {
 	src: ['test/fixtures/three.tpl.html'],
 	dest: 'tmp/multi_lines.js'
       },
+      rename: {
+        options: {
+          rename: function(moduleName) {
+            return moduleName.replace('.html', '');
+          }
+        },
+        src: ['test/fixtures/one.tpl.html', 'test/fixtures/two.tpl.html'],
+        dest: 'tmp/rename.js'          
+      }
     },
 
     // Unit tests.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ The name of the parent Angular module for each set of templates.  Defaults to th
 
 If no bundle module is desired, set this to false.
 
+#### options.rename
+Type: `Function`
+Default value: `none`
+
+A function that takes in the module identifier and returns the renamed module identifier to use instead for the template.  For example, a template located at `src/projects/projects.tpl.html` would be identified as `/src/projects/projects.tpl` with a rename function defined as:
+
+```
+function (moduleName) {
+  return '/' + moduleName.replace('.html', '');
+}
+```
+
 ### Usage Examples
 
 See the `Gruntfile.js` in the project source code for various configuration examples.

--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -65,6 +65,9 @@ module.exports = function(grunt) {
       var modules = f.src.filter(existsFilter).map(function(filepath) {
 
         var moduleName = normalizePath(path.relative(options.base, filepath));
+        if(grunt.util.kindOf(options.rename) === 'function') {
+          moduleName = options.rename(moduleName);
+        }
         moduleNames.push("'" + moduleName + "'");
 
         return compileTemplate(moduleName, filepath);

--- a/test/expected/rename.js
+++ b/test/expected/rename.js
@@ -1,0 +1,11 @@
+angular.module('templates-rename', ['../test/fixtures/one.tpl', '../test/fixtures/two.tpl']);
+
+angular.module("../test/fixtures/one.tpl", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/one.tpl",
+    "1 2 3");
+}]);
+
+angular.module("../test/fixtures/two.tpl", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/two.tpl",
+    "Testing");
+}]);

--- a/test/html2js_test.js
+++ b/test/html2js_test.js
@@ -120,5 +120,15 @@ exports.html2js = {
           'expected compiled template module');
 
     test.done();
+  },
+  rename: function(test) {
+
+    test.expect(1);
+
+    assertFileContentsEqual(test, 'tmp/rename.js',
+          'test/expected/rename.js',
+          'expected compiled template module');
+
+    test.done();
   }
 };


### PR DESCRIPTION
We wanted to only use the templateCache in our production environment so we wanted our templateUrl to be compatible with both the module identifier created with grunt-html2js as well as our Express web server serving up .ejs files (which are basically static html files for our angular templates) in our dev environment.

Using a rename function we can add a leading slash and remove the .ejs from the module identifier keeping it the same as what we use in our dev environment. 

Our existing templateUrl: `/directives/user-badge`
Output before the rename function: `directives/user-badge.ejs`
Output after the rename function: `/directives/user-badge`

Please let me know if there is a better way to do something like this in the existing grunt-html2js. Thanks!
