### PR TITLE
Add config options to support various alternate jshint/jslint/coding convention styles

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -94,6 +94,38 @@ module.exports = function(grunt) {
 	src: ['test/fixtures/three.tpl.html'],
 	dest: 'tmp/multi_lines.js'
       },
+      double_quotes: {
+        src: ['test/fixtures/four.tpl.html'],
+        dest: 'tmp/double_quotes.js'
+      },
+      single_quotes: {
+        src: ['test/fixtures/four.tpl.html'],
+        dest: 'tmp/single_quotes.js',
+        options: {
+          quoteChar: '\''
+        }
+      },
+      multi_lines_tabs: {
+        src: ['test/fixtures/three.tpl.html'],
+        dest: 'tmp/multi_lines_tabs.js',
+        options: {
+          indentString: '\t'
+        }
+      },
+      multi_lines_4space: {
+        src: ['test/fixtures/three.tpl.html'],
+        dest: 'tmp/multi_lines_4spaces.js',
+        options: {
+          indentString: '    '
+        }
+      },
+      file_header: {
+        src: ['test/fixtures/three.tpl.html'],
+        dest: 'tmp/file_header.js',
+        options: {
+          fileHeaderString: '/* global angular: false */\n'
+        }
+      },
       rename: {
         options: {
           rename: function(moduleName) {

--- a/test/expected/double_quotes.js
+++ b/test/expected/double_quotes.js
@@ -1,0 +1,8 @@
+angular.module('templates-double_quotes', ['../test/fixtures/four.tpl.html']);
+
+angular.module("../test/fixtures/four.tpl.html", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/four.tpl.html",
+    "This data is \"in quotes\"\n" +
+    "And this data is 'in single quotes'\n" +
+    "");
+}]);

--- a/test/expected/file_header.js
+++ b/test/expected/file_header.js
@@ -1,0 +1,10 @@
+/* global angular: false */
+
+angular.module('templates-file_header', ['../test/fixtures/three.tpl.html']);
+
+angular.module("../test/fixtures/three.tpl.html", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/three.tpl.html",
+    "Multiple\n" +
+    "Lines\n" +
+    "");
+}]);

--- a/test/expected/multi_lines_4spaces.js
+++ b/test/expected/multi_lines_4spaces.js
@@ -1,0 +1,8 @@
+angular.module('templates-multi_lines_4space', ['../test/fixtures/three.tpl.html']);
+
+angular.module("../test/fixtures/three.tpl.html", []).run(["$templateCache", function($templateCache) {
+    $templateCache.put("../test/fixtures/three.tpl.html",
+        "Multiple\n" +
+        "Lines\n" +
+        "");
+}]);

--- a/test/expected/multi_lines_tabs.js
+++ b/test/expected/multi_lines_tabs.js
@@ -1,0 +1,8 @@
+angular.module('templates-multi_lines_tabs', ['../test/fixtures/three.tpl.html']);
+
+angular.module("../test/fixtures/three.tpl.html", []).run(["$templateCache", function($templateCache) {
+	$templateCache.put("../test/fixtures/three.tpl.html",
+		"Multiple\n" +
+		"Lines\n" +
+		"");
+}]);

--- a/test/expected/single_quotes.js
+++ b/test/expected/single_quotes.js
@@ -1,0 +1,8 @@
+angular.module('templates-single_quotes', ['../test/fixtures/four.tpl.html']);
+
+angular.module('../test/fixtures/four.tpl.html', []).run(['$templateCache', function($templateCache) {
+  $templateCache.put('../test/fixtures/four.tpl.html',
+    'This data is "in quotes"\n' +
+    'And this data is \'in single quotes\'\n' +
+    '');
+}]);

--- a/test/fixtures/four.tpl.html
+++ b/test/fixtures/four.tpl.html
@@ -1,0 +1,2 @@
+This data is "in quotes"
+And this data is 'in single quotes'

--- a/test/html2js_test.js
+++ b/test/html2js_test.js
@@ -121,6 +121,56 @@ exports.html2js = {
 
     test.done();
   },
+  multi_lines_4spaces: function(test) {
+
+    test.expect(1);
+
+    assertFileContentsEqual(test, 'tmp/multi_lines_4spaces.js',
+        'test/expected/multi_lines_4spaces.js',
+        'expected compiled template module');
+
+    test.done();
+  },
+  multi_lines_tabs: function(test) {
+
+    test.expect(1);
+
+    assertFileContentsEqual(test, 'tmp/multi_lines_tabs.js',
+        'test/expected/multi_lines_tabs.js',
+        'expected compiled template module');
+
+    test.done();
+  },
+  double_quotes: function(test) {
+
+    test.expect(1);
+
+    assertFileContentsEqual(test, 'tmp/double_quotes.js',
+        'test/expected/double_quotes.js',
+        'expected compiled template module');
+
+    test.done();
+  },
+  single_quotes: function(test) {
+
+    test.expect(1);
+
+    assertFileContentsEqual(test, 'tmp/single_quotes.js',
+        'test/expected/single_quotes.js',
+        'expected compiled template module');
+
+    test.done();
+  },
+  file_header: function(test) {
+
+    test.expect(1);
+
+    assertFileContentsEqual(test, 'tmp/file_header.js',
+        'test/expected/file_header.js',
+        'expected compiled template module');
+
+    test.done();
+  },
   rename: function(test) {
 
     test.expect(1);


### PR DESCRIPTION
Depending on individual projects' jshint/jslint settings and/or
whitespace specifications, the default choices for multi-line
indenting and quote escaping may not be suitable.  In addition,
there may be particular file-level jshint settings that a project
may want.  The changes in this commit add the following configuration
options to address this:
- quoteChar: by default the quote character remains a double quote
  (").  However, for projects that want strict single quote-only
  usage, you can specify
  `options: { quoteChar: '\'' /*, ... */ }`
  to use single quotes, or any other odd quoting character you want
- indentString: by default the indent remains 2-spaces.  However,
  you can specify alternate indenting via 
  `options: { indentString: '    ' /*, ... */ }`
  to get, for example, 4-space indents.  Same goes for tabs or any other
  indent system you wantto use
- fileHeaderString: If specified in the options
  `options: { fileHeaderString: '/* something here */\n' /*, ... */ })`
  whatever is in the fileHeaderString will get written at the top of the output
  Template.js file.  As an example, jshint directives to e.g.
  `/* global angular: false */` can be put at the head of the file
