### PR TITLE
added option to 'use strict' in generated modules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -160,6 +160,14 @@ module.exports = function(grunt) {
         },
         src: ['test/fixtures/one.tpl.html', 'test/fixtures/two.tpl.html'],
         dest: 'tmp/coffee.coffee'
+      },
+      
+      strict_mode: {
+        options: {
+          useStrict: true
+        },
+        src: ['test/fixtures/one.tpl.html'],
+        dest: 'tmp/strict_mode.js'
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ If specified, this string  will get written at the end of the output
 file.  May be used in conjunction with `fileHeaderString` to wrap
 the output.
 
+#### useStrict: 
+Type: `Boolean`
+Default value: ``
+
+If set true, each module in JavaScript will have 'use strict'; written at the top of the
+module.  Useful for global strict jshint settings.
+
+```
+options: { useStrict: true }
+```
+
 ### Usage Examples
 
 See the `Gruntfile.js` in the project source code for various configuration examples.

--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -39,14 +39,15 @@ module.exports = function(grunt) {
   };
 
   // compile a template to an angular module
-  var compileTemplate = function(moduleName, filepath, quoteChar, indentString) {
+  var compileTemplate = function(moduleName, filepath, quoteChar, indentString, useStrict) {
 
     var content = escapeContent(grunt.file.read(filepath), quoteChar, indentString);
     var doubleIndent = indentString + indentString;
+    var strict = (useStrict) ? indentString + quoteChar + 'use strict' + quoteChar + ';\n' : '';
 
     var module = 'angular.module(' + quoteChar + moduleName +
       quoteChar + ', []).run([' + quoteChar + '$templateCache' + quoteChar + ', function($templateCache) ' +
-      '{\n' + indentString + '$templateCache.put(' + quoteChar + moduleName + quoteChar + ',\n' + doubleIndent  + quoteChar +  content +
+      '{\n' + strict + indentString + '$templateCache.put(' + quoteChar + moduleName + quoteChar + ',\n' + doubleIndent  + quoteChar +  content +
        quoteChar + ');\n}]);\n';
 
     return module;
@@ -92,14 +93,14 @@ module.exports = function(grunt) {
         }
         moduleNames.push("'" + moduleName + "'");
         if (options.target === 'js') {
-          return compileTemplate(moduleName, filepath, options.quoteChar, options.indentString);
+          return compileTemplate(moduleName, filepath, options.quoteChar, options.indentString, options.useStrict);
         } else if (options.target === 'coffee') {
           return compileCoffeeTemplate(moduleName, filepath, options.quoteChar, options.indentString);
         } else {
           grunt.fail.fatal('Unknow target "' + options.target + '" specified');
         }
 
-      }).join(grunt.util.normalizelf('\n'));
+      }).join('\n');
 
       var fileHeader = options.fileHeaderString !== '' ? options.fileHeaderString + '\n' : '';
       var fileFooter = options.fileFooterString !== '' ? options.fileFooterString + '\n' : '';
@@ -114,7 +115,7 @@ module.exports = function(grunt) {
 
         bundle += "\n\n";
       }
-      grunt.file.write(f.dest, fileHeader + bundle + modules + fileFooter);
+      grunt.file.write(f.dest, grunt.util.normalizelf(fileHeader + bundle + modules + fileFooter));
     });
     //Just have one output, so if we making thirty files it only does one line
     grunt.log.writeln("Successfully converted "+(""+this.files.length).green +

--- a/test/expected/strict_mode.js
+++ b/test/expected/strict_mode.js
@@ -1,0 +1,7 @@
+angular.module('templates-strict_mode', ['../test/fixtures/one.tpl.html']);
+
+angular.module("../test/fixtures/one.tpl.html", []).run(["$templateCache", function($templateCache) {
+  "use strict";
+  $templateCache.put("../test/fixtures/one.tpl.html",
+    "1 2 3");
+}]);

--- a/test/html2js_test.js
+++ b/test/html2js_test.js
@@ -25,7 +25,7 @@ var grunt = require('grunt');
 var assertFileContentsEqual = function(test, actualFile, expectedFile, message) {
 
   var actual = grunt.file.read(actualFile);
-  var expected = grunt.file.read(expectedFile);
+  var expected = grunt.util.normalizelf(grunt.file.read(expectedFile));
   test.equal(actual, expected, message);
 };
 
@@ -201,5 +201,15 @@ exports.html2js = {
           'expected compiled template module');
 
     test.done();
-  }
+  },
+  strict_mode: function(test) {
+
+    test.expect(1);
+
+    assertFileContentsEqual(test, 'tmp/strict_mode.js',
+          'test/expected/strict_mode.js',
+          'expected strict mode in templates');
+
+    test.done();
+  },
 };


### PR DESCRIPTION
I am using strict mode in jshint and running against all files.  This allows inserting the 'use strict' statement in each template module.  I also normalized the line endings of the entire file (rather than just templates), and am then comparing the output to normalized versions of the input so the tests pass for Windows users.
