### PR TITLE
html-minifier moved from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,15 @@
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.0",
-    "html-minifier": "~0.5"
+    "grunt": "~0.4.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"
   },
   "keywords": [
     "gruntplugin"
-  ]
+  ],
+  "dependencies": {
+    "html-minifier": "~0.5.4"
+  }
 }


### PR DESCRIPTION
This makes grunt-html2js usable again when using it as grunt task.
