### PR TITLE
chore(grunt): adds grunt-conventional-changelog

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -191,6 +191,12 @@ module.exports = function(grunt) {
     // Unit tests.
     nodeunit: {
       tests: ['test/*_test.js']
+    },
+
+    changelog: {
+      options: {
+        dest: 'CHANGELOG.md'
+      }
     }
   });
 
@@ -201,6 +207,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
+  grunt.loadNpmTasks('grunt-conventional-changelog');
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.0"
+    "grunt": "~0.4.0",
+    "grunt-conventional-changelog": "~1.0.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"


### PR DESCRIPTION
this commits adds the grunt-conventional-changelog plugin to auto
generate changelogs over time

the conventions are used by the angular.js project as well as
other well known angular modules out there

conventions: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit

example output: https://github.com/karma-runner/karma/blob/master/CHANGELOG.md
