### PR TITLE
chore(grunt): adds load-grunt-tasks module

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -198,9 +198,7 @@ module.exports = function(grunt) {
   grunt.loadTasks('tasks');
 
   // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-nodeunit');
+  require('load-grunt-tasks')(grunt);
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.0"
+    "grunt": "~0.4.0",
+    "load-grunt-tasks": "~0.2.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"


### PR DESCRIPTION
makes it easier to maintain grunt plugins that have to be loaded
