### PR TITLE
Trim content

### DIFF
--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -61,7 +61,8 @@ module.exports = function(grunt) {
       }
     } 
     
-    content = content.trim();
+    // trim leading whitespace
+    content = content.replace(/(^\s*)/g, '');
 
     return escapeContent(content, quoteChar, indentString);
   };


### PR DESCRIPTION
Prevents the BOM from being added to the beginning of a template. If a template file has a BOM and the content is not trimmed then an empty line will be rendered where the template is injected.
