### PR TITLE
updated grunt-contrib-nodeunit version to fix nodeunit exception

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -171,7 +171,7 @@ module.exports = function(grunt) {
         src: ['test/fixtures/one.tpl.html', 'test/fixtures/two.tpl.html'],
         dest: 'tmp/coffee.coffee'
       },
-      
+
       strict_mode: {
         options: {
           useStrict: true
@@ -220,6 +220,11 @@ module.exports = function(grunt) {
         },
         src: ['test/fixtures/process_function.tpl.html'],
         dest: 'tmp/process_function.js'
+      },
+
+      process_jade: {
+        src: ['test/fixtures/process_jade.jade'],
+        dest: 'tmp/process_jade.js'
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "html-minifier": "~0.6.0"
+    "html-minifier": "~0.6.0",
+    "jade": "^1.3.1"
   }
 }

--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
 
   var path = require('path');
   var minify = require('html-minifier').minify;
+  var jade = require('jade');
 
   var escapeContent = function(content, quoteChar, indentString) {
     var bsRegexp = new RegExp('\\\\', 'g');
@@ -39,9 +40,17 @@ module.exports = function(grunt) {
     }
   };
 
+  function isJadeTemplate(filepath) {
+    var jadeExtension = /\.jade$/;
+    return jadeExtension.test(filepath);
+  }
+
   // return template content
   var getContent = function(filepath, quoteChar, indentString, htmlmin, process) {
     var content = grunt.file.read(filepath);
+    if (isJadeTemplate(filepath)) {
+      content = jade.render(content);
+    }
 
     // Process files as templates if requested.
     if (typeof process === "function") {
@@ -59,8 +68,8 @@ module.exports = function(grunt) {
       } catch (err) {
         grunt.warn(filepath + '\n' + err);
       }
-    } 
-    
+    }
+
     // trim leading whitespace
     content = content.replace(/(^\s*)/g, '');
 

--- a/test/expected/process_jade.js
+++ b/test/expected/process_jade.js
@@ -1,0 +1,6 @@
+angular.module('templates-process_jade', ['../test/fixtures/process_jade.jade']);
+
+angular.module("../test/fixtures/process_jade.jade", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/process_jade.jade",
+    "<p class=\"example\">Hello World!</p>");
+}]);

--- a/test/fixtures/process_jade.jade
+++ b/test/fixtures/process_jade.jade
@@ -1,0 +1,1 @@
+p.example Hello World!

--- a/test/html2js_test.js
+++ b/test/html2js_test.js
@@ -249,5 +249,14 @@ exports.html2js = {
         'expected grunt templates to be processed by a custom function');
 
     test.done();
-  }
+  },
+  process_jade: function(test) {
+    test.expect(1);
+
+    assertFileContentsEqual(test, 'tmp/process_jade.js',
+        'test/expected/process_jade.js',
+        'expected jade template to be processed');
+
+    test.done();
+  },
 };


### PR DESCRIPTION
Grabbed the existing repo, tried running grunt - it could not load nodeunit. Here is the error message from `grunt -v nodeunit`

```
Registering "grunt-contrib-nodeunit" local Npm module tasks.
Reading /Users/gleb/git/grunt-html2js/node_modules/grunt-contrib-nodeunit/package.json...OK
Parsing /Users/gleb/git/grunt-html2js/node_modules/grunt-contrib-nodeunit/package.json...OK
Loading "nodeunit.js" tasks...ERROR
>> Error: No such module
>>     at Object.<anonymous> (/Users/gleb/git/grunt-html2js/node_modules/grunt-contrib-nodeunit/node_modules/nodeunit/lib/utils.js:14:22)
>>     at Module._compile (module.js:449:26)
```

upgrading grunt-contrib-nodeunit solved it.
