### PR TITLE
Allow custom Jade options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -227,6 +227,14 @@ module.exports = function(grunt) {
         dest: 'tmp/process_jade.js'
       },
 
+      process_jade_custom: {
+        options: {
+          jade: {doctype: 'html'}
+        },
+        src: ['test/fixtures/process_jade_custom.jade'],
+        dest: 'tmp/process_jade_custom.js'
+      },
+
       single_module: {
         options: {
           singleModule: true

--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -49,9 +49,7 @@ module.exports = function(grunt) {
   var getContent = function(filepath, options) {
     var content = grunt.file.read(filepath);
     if (isJadeTemplate(filepath)) {
-      content = jade.render(content, {
-        pretty: true
-      });
+      content = jade.render(content, options.jade);
     }
 
     // Process files as templates if requested.
@@ -140,6 +138,7 @@ module.exports = function(grunt) {
       target: 'js',
       htmlmin: {},
       process: false,
+      jade: { pretty: true },
       singleModule: false
     });
 

--- a/test/expected/process_jade_custom.js
+++ b/test/expected/process_jade_custom.js
@@ -1,0 +1,6 @@
+angular.module('templates-process_jade_custom', ['../test/fixtures/process_jade_custom.jade']);
+
+angular.module("../test/fixtures/process_jade_custom.jade", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/process_jade_custom.jade",
+    "<a href>Great</a>");
+}]);

--- a/test/fixtures/process_jade_custom.jade
+++ b/test/fixtures/process_jade_custom.jade
@@ -1,0 +1,1 @@
+a(href) Great

--- a/test/html2js_test.js
+++ b/test/html2js_test.js
@@ -259,6 +259,15 @@ exports.html2js = {
 
     test.done();
   },
+  process_jade_with_custom_options: function(test) {
+    test.expect(1);
+
+    assertFileContentsEqual(test, 'tmp/process_jade_custom.js',
+        'test/expected/process_jade_custom.js',
+        'expected jade template to be processed with custom options');
+
+    test.done();
+  },
   single_module: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
This allows custom Jade options to be set. Particularly useful, in my case, for when I need to preset the doctype for all templates, as this changes how Jade compiles the templates, particularly boolean HTML attributes.
