### PR TITLE
Set the jade filename property in order to support relative includes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -235,6 +235,14 @@ module.exports = function(grunt) {
         dest: 'tmp/process_jade_custom.js'
       },
 
+      process_jade_with_include: {
+        options: {
+          jade: {}
+        },
+        src: ['test/fixtures/process_jade_with_include.jade'],
+        dest: 'tmp/process_jade_with_include.js'
+      },
+
       single_module: {
         options: {
           singleModule: true

--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -49,6 +49,7 @@ module.exports = function(grunt) {
   var getContent = function(filepath, options) {
     var content = grunt.file.read(filepath);
     if (isJadeTemplate(filepath)) {
+      options.jade.filename = filepath;
       content = jade.render(content, options.jade);
     }
 

--- a/test/expected/process_jade_with_include.js
+++ b/test/expected/process_jade_with_include.js
@@ -1,0 +1,6 @@
+angular.module('templates-process_jade_with_include', ['../test/fixtures/process_jade_with_include.jade']);
+
+angular.module("../test/fixtures/process_jade_with_include.jade", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/process_jade_with_include.jade",
+    "<h1>I'm an include!</h1>");
+}]);

--- a/test/fixtures/jade_include.jade
+++ b/test/fixtures/jade_include.jade
@@ -1,0 +1,1 @@
+h1 I'm an include!

--- a/test/fixtures/process_jade_with_include.jade
+++ b/test/fixtures/process_jade_with_include.jade
@@ -1,0 +1,1 @@
+include ./jade_include

--- a/test/html2js_test.js
+++ b/test/html2js_test.js
@@ -268,6 +268,14 @@ exports.html2js = {
 
     test.done();
   },
+  process_jade_with_include: function(test) {
+    test.expect(1);
+    assertFileContentsEqual(test, 'tmp/process_jade_with_include.js',
+        'test/expected/process_jade_with_include.js',
+        'expected jade template to be processed with custom options');
+
+    test.done();
+  },
   single_module: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
Currently if you declare a relative include in a jade file you will get the error: 
`the "filename" option is required to use "include" with "relative" paths`

The fix is very simple, just assign options.jade.filename to the filepath.

``` js
options.jade.filename = filepath;
```

Included a new unit test `process_jade_with_include`.
