### PR TITLE
file watch, cache and re-compile feature

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -248,6 +248,15 @@ module.exports = function(grunt) {
         dest: 'tmp/process_jade_with_include.js'
       },
 
+      process_all_jade: {
+        options: {
+          jade: {},
+          watch: true
+        },
+        src: ['test/fixtures/*.jade'],
+        dest: 'tmp/process_all_jade.js'
+      },
+
       single_module: {
         options: {
           singleModule: true

--- a/README.md
+++ b/README.md
@@ -194,6 +194,21 @@ Default value: `false`
 
 If set to true, will create a single wrapping module with a run block, instead of an individual module for each template file. Requres that the `module` option is not falsy.
 
+#### watch
+Type: `Boolean`
+Default value: `false`
+
+If set to true and used inconjunction with a long running/keep-alive process such as grunt-contrib-watch html2js will watch src files for changes and regenerate output to dest. It uses an internal cache so only the file that changes needs to be re-compliled. Useful for development process particularly if you have lots of jade templates. It is very similar to grunt-browserify's watch.
+
+N.B. If using grunt-watch you do not need to run the html2js task again on src changes as it watches internally for these. All you need to do is watch the destination file and live reload on change.
+
+```
+options: {
+  jade: {},
+  watch: true
+}
+```
+
 ### Jade support
 
 If template filename ends with `.jade` the task will automatically render file's content using [Jade](https://github.com/visionmedia/jade)
@@ -205,7 +220,7 @@ Options can be passed to Jade within a `jade` property in the plugin options.
 options: {
   jade: {
     //this prevents auto expansion of empty arguments
-    //e.g. "div(ui-view)" becomes "<div ui-view></div>" 
+    //e.g. "div(ui-view)" becomes "<div ui-view></div>"
     //     instead of "<div ui-view="ui-view"></div>"
     doctype: "html"
   }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gruntplugin"
   ],
   "dependencies": {
+    "chokidar": "^1.0.0-rc5",
     "html-minifier": "~0.6.0",
     "jade": "^1.3.1"
   }

--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -147,14 +147,12 @@ module.exports = function(grunt) {
     var target = this.target;
 
     if (options.watch) {
-      var files = this.files
-      var fileCache = {}
+      var files = this.files;
+      var fileCache = {};
       var chokidar = require('chokidar');
-      var watcher = chokidar.watch(null,{
-        persistent: true
-      }).on('change', function(path) {
+      var watcher = chokidar.watch().on('change', function(filepath) {
         // invalidate cache
-        fileCache[path] = null;
+        fileCache[filepath] = null;
         // regenerateModules
         files.forEach(generateModule);
       });
@@ -165,9 +163,11 @@ module.exports = function(grunt) {
 
       // f.dest must be a string or write will fail
       var moduleNames = [];
-      var filePaths = f.src.filter(existsFilter)
-      if (options.watch)
-        watcher.add(filePaths)
+      var filePaths = f.src.filter(existsFilter);
+
+      if (options.watch) {
+        watcher.add(filePaths);
+      }
 
       var modules = filePaths.map(function(filepath) {
         var compiled;
@@ -192,7 +192,7 @@ module.exports = function(grunt) {
 
         if (options.watch) {
           // store compiled file contents in cache
-          fileCache[filepath] = compiled
+          fileCache[filepath] = compiled;
         }
 
         return compiled;
@@ -237,7 +237,7 @@ module.exports = function(grunt) {
       grunt.file.write(f.dest, grunt.util.normalizelf(fileHeader + bundle + modules + fileFooter));
     }
 
-    this.files.forEach(generateModule)
+    this.files.forEach(generateModule);
 
     //Just have one output, so if we making thirty files it only does one line
     grunt.log.writeln("Successfully converted "+(""+counter).green +

--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -170,6 +170,13 @@ module.exports = function(grunt) {
       }
 
       var modules = filePaths.map(function(filepath) {
+
+        var moduleName = normalizePath(path.relative(options.base, filepath));
+        if (grunt.util.kindOf(options.rename) === 'function') {
+          moduleName = options.rename(moduleName);
+        }
+        moduleNames.push("'" + moduleName + "'");
+
         var compiled;
 
         if (options.watch && (compiled = fileCache[filepath])) {
@@ -177,11 +184,6 @@ module.exports = function(grunt) {
           return compiled;
         }
 
-        var moduleName = normalizePath(path.relative(options.base, filepath));
-        if (grunt.util.kindOf(options.rename) === 'function') {
-          moduleName = options.rename(moduleName);
-        }
-        moduleNames.push("'" + moduleName + "'");
         if (options.target === 'js') {
           compiled = compileTemplate(moduleName, filepath, options);
         } else if (options.target === 'coffee') {

--- a/test/expected/process_all_jade.js
+++ b/test/expected/process_all_jade.js
@@ -1,0 +1,21 @@
+angular.module('templates-process_all_jade', ['../test/fixtures/jade_include.jade', '../test/fixtures/process_jade.jade', '../test/fixtures/process_jade_custom.jade', '../test/fixtures/process_jade_with_include.jade']);
+
+angular.module("../test/fixtures/jade_include.jade", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/jade_include.jade",
+    "<h1>I'm an include!</h1>");
+}]);
+
+angular.module("../test/fixtures/process_jade.jade", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/process_jade.jade",
+    "<p class=\"example\">Hello World!</p><div id=\"greeting\">Nice</div>");
+}]);
+
+angular.module("../test/fixtures/process_jade_custom.jade", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/process_jade_custom.jade",
+    "<a href=\"href\">Great</a>");
+}]);
+
+angular.module("../test/fixtures/process_jade_with_include.jade", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/process_jade_with_include.jade",
+    "<h1>I'm an include!</h1>");
+}]);

--- a/test/expected/process_all_jade_after_change.js
+++ b/test/expected/process_all_jade_after_change.js
@@ -1,0 +1,21 @@
+angular.module('templates-process_all_jade', ['../test/fixtures/jade_include.jade', '../test/fixtures/process_jade.jade', '../test/fixtures/process_jade_custom.jade', '../test/fixtures/process_jade_with_include.jade']);
+
+angular.module("../test/fixtures/jade_include.jade", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/jade_include.jade",
+    "<h1>I'm an include!</h1>");
+}]);
+
+angular.module("../test/fixtures/process_jade.jade", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/process_jade.jade",
+    "<p class=\"example\">Hello World!</p><div id=\"greeting\">Nice</div><div id=\"watch\">test</div>");
+}]);
+
+angular.module("../test/fixtures/process_jade_custom.jade", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/process_jade_custom.jade",
+    "<a href=\"href\">Great</a>");
+}]);
+
+angular.module("../test/fixtures/process_jade_with_include.jade", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/process_jade_with_include.jade",
+    "<h1>I'm an include!</h1>");
+}]);

--- a/test/html2js_test.js
+++ b/test/html2js_test.js
@@ -304,6 +304,31 @@ exports.html2js = {
 
     test.done();
   },
+  process_all_jade: function(test) {
+    test.expect(1);
+
+    // This test is run with options.watch on
+    // We need to edit a fixture file to make sure it is watched and re-compiled
+    var file2Change = 'test/fixtures/process_jade.jade';
+    var contents = grunt.file.read(file2Change);
+    var newContents = contents + "\n#watch test";
+
+    // Write edited fixture file
+    grunt.file.write(file2Change, grunt.util.normalizelf(newContents));
+
+    // wait for the watch-change to process
+    setTimeout(function(){
+        // Check re-compiled with changes were added
+        assertFileContentsEqual(test, 'tmp/process_all_jade.js',
+          'test/expected/process_all_jade_after_change.js',
+          'expected jade template to be processed with custom options');
+
+        //reset fixture file to original contents
+        grunt.file.write(file2Change, grunt.util.normalizelf(contents));
+        test.done();
+    } , 1000);
+
+  },
   single_module: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
Hi,

I wrote this pull request because we use this on a project with some 30+ jade templates which we compile into a single module (templates.js). When developing we use grunt-watch to look for file changes and call html2js to re-compile and then live reload. When you have many templates and use jade, a change means that it must re-read all the files, re-compile each jade file, then convert it to a js template and then write the final dest file. This can take several seconds on a slow computer.  

This feature when turned on and used in-conjunction with a long running process like live-reload/watch will watch internally for src file changes and regenerate output to dest. 

It uses an internal cache so only the file that changes needs to be read from the file system and re-compliled. It can reduce the time from 7-10 seconds in my case to <  .5s.

I have written a test that works, but it is probably not the most elegant solution. Apart from the test I have written I have used it in conjunction with our project and it seems to work very well but I haven't tested it with lots of different html2js configurations. 

It uses chokidar for the file watching which is the best file watch solution I have found for node and I;ve used it successfully in several other projects. It might be better served in dev-deps than deps as watch is really only suppose to be used in a dev environment.

If you're interested in merging this upstream I would be happy to do any extra stuff to improve it.