### PR TITLE
Require jade on demand.

### DIFF
--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -12,7 +12,6 @@ module.exports = function(grunt) {
 
   var path = require('path');
   var minify = require('html-minifier').minify;
-  var jade = require('jade');
 
   var escapeContent = function(content, quoteChar, indentString) {
     var bsRegexp = new RegExp('\\\\', 'g');
@@ -48,6 +47,7 @@ module.exports = function(grunt) {
   var getContent = function(filepath, options) {
     var content = grunt.file.read(filepath);
     if (isJadeTemplate(filepath)) {
+      var jade = require('jade');
       options.jade.filename = filepath;
       content = jade.render(content, options.jade);
     }


### PR DESCRIPTION
Significantly reduces startup time (~300 ms on this machine).

Noticed that a significant chunk of my Grunt time was spent loading grunt-html2js. Seemed odd. Turns out that jade is the culprit.

In any case, even if jade gets fixed, there's no need to `require` it when it isn't getting used.