### PR TITLE
Make jade an optionalDependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,17 +33,20 @@
     "grunt-contrib-nodeunit": "^0.3.3",
     "grunt": "~0.4.0",
     "grunt-conventional-changelog": "~1.0.0",
-    "load-grunt-tasks": "~0.2.0"
+    "load-grunt-tasks": "~0.2.0",
+    "jade": "^1.3.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"
+  },
+  "optionalDependencies": {
+    "jade": "^1.3.1"
   },
   "keywords": [
     "gruntplugin"
   ],
   "dependencies": {
     "chokidar": "^1.0.0",
-    "html-minifier": "~0.6.0",
-    "jade": "^1.3.1"
+    "html-minifier": "~0.6.0"
   }
 }


### PR DESCRIPTION
Many/most users of grunt-html2js won't need it.